### PR TITLE
Fix predict.ptw with 'forward' mode

### DIFF
--- a/ptw/R/predict.ptw.R
+++ b/ptw/R/predict.ptw.R
@@ -1,6 +1,3 @@
-## THIS FILE NEEDS THOROUGH REVISION DUE TO THE INTRODUCTION OF
-## FORWARD/BACKWARD WARPING !!!
-
 ## Paril 1 :-), 2011 (RW)
 ## First working version of predict.ptw.
 
@@ -39,13 +36,25 @@ predict.ptw <- function(object, newdata,
            }
 
            ## do the warping
-           t(sapply(1:nrow(newdata),
-                    function(i) ##interpol(WF[i,], newdata[i,])))
-                      approx(newdata[i,], NULL, WF[i,])$y))
+           if (object$mode == "backward") {
+             t(sapply(1:nrow(newdata),
+                      function(i) ##interpol(WF[i,], newdata[i,])))
+                        approx(x = 1:ncol(newdata), y = newdata[i,],
+                               xout = WF[i,])$y))
+           } else { # object$mode == "forward"
+             t(sapply(1:nrow(newdata),
+                      function(i)
+                        approx(x = WF[i,], y = newdata[i,],
+                               xout = 1:ncol(newdata))$y))
+           }
          },
          time = {
-           correctedTime <- 
-             -sweep(object$warp.fun, 2, 2*(1:ncol(object$ref)), FUN = "-")
+           if (object$mode == "backward") {
+             correctedTime <- 
+               -sweep(object$warp.fun, 2, 2*(1:ncol(object$ref)), FUN = "-")
+           } else {
+             correctedTime <- object$warp.fun
+           }
            if (is.null(RTref)){
              if (is.null(colnames(object$ref))) {
                RTref <- 1:ncol(object$ref)

--- a/ptw/TODO
+++ b/ptw/TODO
@@ -1,5 +1,4 @@
 - complete example for warp.time
 - add stptw info to ptw man page
-- check predict.ptw: does it work for both backward and forward warping?
 - complete example for stptw
 - check examples voor plot.ptw, summary.ptw etc

--- a/ptw/tests/test_predict.ptw.R
+++ b/ptw/tests/test_predict.ptw.R
@@ -1,0 +1,16 @@
+x1 <- c(rep(0, 5), 1,1,1, 20, 40, 20, 1, 1, 1, rep(0, 5))
+x2 <- c(rep(0, 6), 1,1,1, 20, 40, 20, 1, 1, 1, rep(0, 4))
+time <- 1:length(x1)
+library(ptw)
+w1b <- ptw(ref = x1, samp = x2, mode = "backward")
+x2wb <- predict(w1b, x2, what = "response")
+stopifnot(sum(abs(x2wb - w1b$warped.sample), na.rm = TRUE) < 1E-8)
+t2wb <- as.numeric(predict(w1b, time, what = "time"))
+stopifnot(sum(abs(tail(t2wb, -1) - head(time, -1)), na.rm = TRUE) < 0.05)
+
+w1f <- ptw(ref = x1, samp = x2, mode = "forward")
+x2wf <- predict(w1f, x2, what = "response")
+stopifnot(sum(abs(x2wf - w1f$warped.sample), na.rm = TRUE) < 1E-8)
+t2wf <- as.numeric(predict(w1f, time, what = "time"))
+stopifnot(sum(abs(tail(t2wf, -1) - head(time, -1)), na.rm = TRUE) < 0.05)
+


### PR DESCRIPTION
This PR fixes `predict.ptw` so it works both in forward and backward mode. It also adds a test file to make sure regressions do not happen in the future.